### PR TITLE
Require Jenkins 2.375.4 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,14 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(
+  // Container agents start faster and are easier to administer
+  useContainerAgent: true,
+  // Show failures on all configurations
+  failFast: false,
+  // Test Java 11 with minimum Jenkins version, Java 17 with a more recent LTS version
+  configurations: [
+    [platform: 'linux',   jdk: '17', jenkins: '2.387.1'], // Linux first for coverage report on ci.jenkins.io
+    [platform: 'windows', jdk: '11'],
+  ]
+)

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>Cron Column Plugin</name>
 
         <properties>
-                <jenkins.version>2.346.3</jenkins.version>
+                <jenkins.version>2.375.4</jenkins.version>
                 <spotbugs.effort>Max</spotbugs.effort>
                 <spotbugs.threshold>Low</spotbugs.threshold>
         </properties>


### PR DESCRIPTION
## Require Jenkins 2.375.4 or newer

- Bump plugin from 4.51 to 4.57
- Require Jenkins 2.375.4 or newer (Java 11)

Over 90% of users that have installed the 1.6 release from several months ago were already running 2.375.1 as of March 1, 2023.  No need to remain on Java 8 when users that are upgrading are already on a Jenkins version that requires Java 11.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
