### PR TITLE
CasC support

### DIFF
--- a/src/main/java/hudson/plugins/CronViewColumn.java
+++ b/src/main/java/hudson/plugins/CronViewColumn.java
@@ -15,6 +15,8 @@ import hudson.views.ListViewColumnDescriptor;
 import java.util.Map;
 import jenkins.model.ParameterizedJobMixIn;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest2;
 
 /**
@@ -31,6 +33,9 @@ public class CronViewColumn extends ListViewColumn {
 
     private static final String CRON_EXPRESSION_COMMENT_START = "#";
     private static final String CRON_EXPRESSION_COMMENT_COLOR = "#4a7b4a";
+
+    @DataBoundConstructor
+    public CronViewColumn() {}
 
     /**
      * @return HTML String containing the cron expression of each Trigger on the Job (when available).
@@ -112,6 +117,7 @@ public class CronViewColumn extends ListViewColumn {
     }
 
     @Extension
+    @Symbol("cronTrigger")
     public static final class DescriptorImpl extends ListViewColumnDescriptor {
         @Override
         public ListViewColumn newInstance(StaplerRequest2 req, JSONObject formData) {


### PR DESCRIPTION
add @Symbol and @DataBoundConstructor

fixes #71

<!-- Please describe your pull request here. -->

### Testing done
Exporting CasC now properly includes the cronTrigger column

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
